### PR TITLE
check if tmpHeight is zero before doing expensive rendering

### DIFF
--- a/js/spectrogram/spectrogram.js
+++ b/js/spectrogram/spectrogram.js
@@ -71,6 +71,9 @@ class _spectrogram {
       if (i===10) {
         gui.renderText(tmpHeight, 200, 30, "#fff", "20px", "Mono");
       }
+
+      if (tmpHeight == 0) continue;
+      
       this.ctx.fillStyle = this.getColor(data[i]);
       this.ctx.fillRect(
         this.viewPortRight - speed,


### PR DESCRIPTION
Signed-off-by: hle0 <91701075+hle0@users.noreply.github.com>

This removes unnecessary and expensive canvas functions if the rectangle we're trying to fill has zero area.