### PR TITLE
contain lots of things in an AudioSystem instead of global variables …

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <script src="js/animFrameLoop.js" charset="utf-8"></script>
     <script src="js/spectrogram/spectrogram.js" charset="utf-8"></script>
     <script src="js/interface/interface.js" charset="utf-8"></script>
+    <script src="js/AudioSystem.js" charset="utf-8"></script>
     <script src="js/main.js" charset="utf-8"></script>
   </body>
 </html>

--- a/js/AudioSystem.js
+++ b/js/AudioSystem.js
@@ -1,0 +1,36 @@
+class AudioSystem {
+    constructor(div, audioStream) {
+        this.div = div;
+        this.audioStream = audioStream;
+
+        this.avgFPS = 0;
+
+        this.fft = new _fftData();
+        this.fft.init(this.audioStream);
+    
+        this.primaryCanvas = this.div.appendChild(document.createElement('canvas'));
+        this.guiCanvas = this.div.appendChild(document.createElement('canvas'));
+
+        this.spec = new _SPECTROGRAM(this);
+        this.spec.updateScale();
+        this.spec.drawScale();
+
+        this.gui = new _GUI(this);
+    }
+
+    update(dt) {
+        if (dt == 0) { return false; } // don't continue if infinite fps
+
+        this.fft.update();
+        this.gui.clear(); // clear the gui layer
+        // show FPS
+        this.avgFPS = ((1/dt) + this.avgFPS * 19) / 20;
+        this.gui.renderText(Math.floor(this.avgFPS), 10, this.spec.viewPortBottom - 10, "#fff", "20px", "Mono");
+        this.spec.updateScale();
+        // spec.drawScale();
+        // spec.clear();
+        this.spec.draw(this.fft.data);
+        this.gui.update();
+        return true;
+    }
+}

--- a/js/interface/interface.js
+++ b/js/interface/interface.js
@@ -3,10 +3,9 @@
 document.addEventListener('contextmenu', event => event.preventDefault()); // stop the rightclick menu from showing
 
 class _GUI {
-  constructor(spec, container=window) {
+  constructor(audioSystem, container=window) {
     this.container = container;
-    this.spec = spec;
-    this.canvas = div.appendChild(document.createElement('canvas'));
+    this.audioSystem = audioSystem;
     this.canvas.width = container.innerWidth;
     this.canvas.height = container.innerHeight;
     this.viewPortRight = this.canvas.width - this.spec.scaleWidth;
@@ -16,6 +15,15 @@ class _GUI {
     this.ruler = [{x:0,y:0,active:false}];
     this.pitchAlert = parseInt(pitchFloorAlert.content);
   }
+
+  get canvas() {
+    return this.audioSystem.guiCanvas;
+  }
+
+  get spec() {
+    return this.audioSystem.spec;
+  }
+
   mouseDown(event) {
     if (event.button === 2) {
       if (this.ruler[0].active === true) {

--- a/js/main.js
+++ b/js/main.js
@@ -2,41 +2,17 @@
 // select an input, then start everything
 navigator.mediaDevices.getUserMedia({ audio: true }).then(initialise).catch(console.log);
 
-let fft, gui, spec;
-let avgFPS = 0;
+let audioSystem;
 
-// starts everything after you select an input
 function initialise(stream) {
-  // make the spectrogram
-  fft = new _fftData();
-  fft.init(stream);
-  spec = new _SPECTROGRAM(fft);
-  spec.updateScale();
-  spec.drawScale();
-  gui = new _GUI(spec, window);
-  startLoop(mainLoop);
+  audioSystem = new AudioSystem(document.querySelector("#div"), stream);
+  startLoop(audioSystem.update.bind(audioSystem));
 }
-
-function mainLoop(dt) {
-  if (dt === 0) { return false } // don't continue if infinite fps
-  fft.update();
-  gui.clear(); // clear the gui layer
-  // show FPS
-  avgFPS = ((1/dt) + avgFPS * 19) / 20;
-  gui.renderText(Math.floor(avgFPS), 10, spec.viewPortBottom - 10, "#fff", "20px", "Mono");
-  spec.updateScale();
-  // spec.drawScale();
-  // spec.clear();
-  spec.draw(fft.data);
-  gui.update();
-  return;
-}
-
 
 //  add spacebar to pause
 const space_bar = 32;
 window.onkeydown = function(gfg){
   if(gfg.keyCode === space_bar) {
-    spec.pauseToggle();
+    audioSystem.spec.pauseToggle();
   }
 };

--- a/js/spectrogram/spectrogram.js
+++ b/js/spectrogram/spectrogram.js
@@ -1,13 +1,12 @@
 
 
 class _SPECTROGRAM {
-  constructor(fft, container=window) {
-    this.fft = fft;
+  constructor(audioSystem, container=window) {
+    this.audioSystem = audioSystem;
     this.container = container;
-    this.sampleRate = fft.audioCtx.sampleRate;
-    this.frequencyBinCount = fft.analyser.fftSize;
+    this.sampleRate = this.fft.audioCtx.sampleRate;
+    this.frequencyBinCount = this.fft.analyser.fftSize;
     // by default creates a spectrogram canvas of the full size of the window
-    this.canvas = div.appendChild(document.createElement('canvas'));
     this.canvas.width = container.innerWidth;
     this.canvas.height = container.innerHeight;
     this.ctx = this.canvas.getContext('2d');
@@ -47,6 +46,15 @@ class _SPECTROGRAM {
     this.clear();
     this.updateScale();
   }
+
+  get canvas() {
+    return this.audioSystem.primaryCanvas;
+  }
+  
+  get fft() {
+    return this.audioSystem.fft;
+  }
+
   update() {
     if (this.pause) {return "paused"}
     this.getFundamental(this.fft.data);


### PR DESCRIPTION
…for reusability

Signed-off-by: hle0 <91701075+hle0@users.noreply.github.com>

Going to merge this immediately, but this is in a pull request to document the changes.

This makes the code more organized so that there aren't a ton of global variables everywhere. The FFT, GUI, and Spectrogram objects are all now contained in AudioSystem. This might allow having multiple spectrograms per page in the future; one idea is to have a separate pitch tracker and spectrogram for the user's voice and for a mimicked voice that would play in a separate AudioStream.